### PR TITLE
README: add link to PDF with slide deck

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# IPFS Camp 2019 Course C Materials
+# IPFS Camp 2019: Course C Demo App
+
+> See [ipfs/camp/CORE_AND_ELECTIVE_COURSES/CORE_COURSE_C](https://github.com/ipfs/camp/blob/master/CORE_AND_ELECTIVE_COURSES/CORE_COURSE_C/README.md) for information about the course.
+
+This is a repo with a demo app for teaching basic use of IPFS API. Finished version enables users to publish and customize their ID Card.  A wall of ID Cards is displayed at all times during the course to increase engagement and creativity:
+![Corse C during IPFS Camp 2019](https://user-images.githubusercontent.com/157609/63440947-ff2b1a80-c430-11e9-8531-0855e17a7fc0.jpg)
 
 ## To run locally
 
@@ -17,3 +22,8 @@ npm start
 
 - [PDF](https://github.com/ipfs/camp/files/3525750/IPFS.Camp.2019.-.Core.Course.C.-.Slide.Deck.pdf) (read-only)
 - [Google Docs](https://docs.google.com/presentation/d/1cbJD5j_jRpm3yJiE6hLIOzMn8iMhvzyci7Ut3NLjqxs/edit?usp=sharing) (copy & edit)
+
+
+## LICENSE
+
+[RoboHash images are available under the CC-BY-3.0 license.](https://github.com/e1ven/Robohash/tree/master/robohash/sets/set4)

--- a/README.md
+++ b/README.md
@@ -14,4 +14,6 @@ npm start
 
 ## Slide deck
 
-[WIP version can be previewed here](https://docs.google.com/presentation/d/1cbJD5j_jRpm3yJiE6hLIOzMn8iMhvzyci7Ut3NLjqxs/edit?usp=sharing), PDF will be published after IPFS Camp :-)
+
+- [PDF](https://github.com/ipfs/camp/files/3525750/IPFS.Camp.2019.-.Core.Course.C.-.Slide.Deck.pdf) (read-only)
+- [Google Docs](https://docs.google.com/presentation/d/1cbJD5j_jRpm3yJiE6hLIOzMn8iMhvzyci7Ut3NLjqxs/edit?usp=sharing) (copy & edit)


### PR DESCRIPTION
> Parent issue: https://github.com/ipfs/camp/pull/178

This PR updates the README with a link to slide deck in PDF format, adds license information about default avatars and shows how the cat board looks like during the course.

Should make it more useful for people visiting it in the future.

cc @jimpick  @hugomrdias @autonome @terichadbourne